### PR TITLE
Added support for the balance board button.

### DIFF
--- a/lib/core.c
+++ b/lib/core.c
@@ -1099,6 +1099,7 @@ static int read_nunchuk(struct xwii_iface *dev, struct xwii_event *ev)
 	int ret, fd;
 	struct input_event input;
 	unsigned int key;
+	static bool EV_SYN_KEY = false;
 
 	fd = dev->ifs[XWII_IF_NUNCHUK].fd;
 	if (fd < 0)
@@ -1131,6 +1132,7 @@ try_again:
 				goto try_again;
 		}
 
+		EV_SYN_KEY = true;
 		memset(ev, 0, sizeof(*ev));
 		memcpy(&ev->time, &input.time, sizeof(struct timeval));
 		ev->type = XWII_EVENT_NUNCHUK_KEY;
@@ -1149,6 +1151,10 @@ try_again:
 		else if (input.code == ABS_RZ)
 			dev->nunchuk_cache[1].z = input.value;
 	} else if (input.type == EV_SYN) {
+		if (EV_SYN_KEY) {
+			EV_SYN_KEY = false;
+			goto try_again;
+		}
 		memset(ev, 0, sizeof(*ev));
 		memcpy(&ev->time, &input.time, sizeof(struct timeval));
 		memcpy(&ev->v.abs, dev->nunchuk_cache,
@@ -1166,6 +1172,7 @@ static int read_classic(struct xwii_iface *dev, struct xwii_event *ev)
 	int ret, fd;
 	struct input_event input;
 	unsigned int key;
+	static bool EV_SYN_KEY = false;
 
 	fd = dev->ifs[XWII_IF_CLASSIC_CONTROLLER].fd;
 	if (fd < 0)
@@ -1237,6 +1244,7 @@ try_again:
 				goto try_again;
 		}
 
+		EV_SYN_KEY = true;
 		memset(ev, 0, sizeof(*ev));
 		memcpy(&ev->time, &input.time, sizeof(struct timeval));
 		ev->type = XWII_EVENT_CLASSIC_CONTROLLER_KEY;
@@ -1257,6 +1265,10 @@ try_again:
 		else if (input.code == ABS_HAT3Y)
 			dev->classic_cache[2].x = input.value;
 	} else if (input.type == EV_SYN) {
+		if (EV_SYN_KEY) {
+			EV_SYN_KEY = false;
+			goto try_again;
+		}
 		memset(ev, 0, sizeof(*ev));
 		memcpy(&ev->time, &input.time, sizeof(struct timeval));
 		memcpy(&ev->v.abs, dev->classic_cache,
@@ -1273,6 +1285,8 @@ static int read_bboard(struct xwii_iface *dev, struct xwii_event *ev)
 {
 	int ret, fd;
 	struct input_event input;
+	unsigned int key;
+	static bool EV_SYN_KEY = false;
 
 	fd = dev->ifs[XWII_IF_BALANCE_BOARD].fd;
 	if (fd < 0)
@@ -1290,26 +1304,42 @@ try_again:
 		return 0;
 	}
 
-	if (input.type == EV_SYN) {
+	if (input.type == EV_KEY) {
+		if (input.code != BTN_A && (input.value < 0 || input.value > 2))
+			goto try_again;
+
+		key = XWII_KEY_A;
+
+		EV_SYN_KEY = true;
+		memset(ev, 0, sizeof(*ev));
+		memcpy(&ev->time, &input.time, sizeof(struct timeval));
+		ev->type = XWII_EVENT_BALANCE_BOARD_KEY;
+		ev->v.key.code = key;
+		ev->v.key.state = input.value;
+		return 0;
+	} else if (input.type == EV_ABS) {
+		if (input.code == ABS_HAT0X)
+			dev->bboard_cache[0].x = input.value;
+		else if (input.code == ABS_HAT0Y)
+			dev->bboard_cache[1].x = input.value;
+		else if (input.code == ABS_HAT1X)
+			dev->bboard_cache[2].x = input.value;
+		else if (input.code == ABS_HAT1Y)
+			dev->bboard_cache[3].x = input.value;
+	} else if (input.type == EV_SYN) {
+		if (EV_SYN_KEY) {
+			EV_SYN_KEY = false;
+			goto try_again;
+		}
+
 		memset(ev, 0, sizeof(*ev));
 		memcpy(&ev->time, &input.time, sizeof(struct timeval));
 		memcpy(&ev->v.abs, dev->bboard_cache,
 		       sizeof(dev->bboard_cache));
 		ev->type = XWII_EVENT_BALANCE_BOARD;
 		return 0;
+	} else {
 	}
-
-	if (input.type != EV_ABS)
-		goto try_again;
-
-	if (input.code == ABS_HAT0X)
-		dev->bboard_cache[0].x = input.value;
-	else if (input.code == ABS_HAT0Y)
-		dev->bboard_cache[1].x = input.value;
-	else if (input.code == ABS_HAT1X)
-		dev->bboard_cache[2].x = input.value;
-	else if (input.code == ABS_HAT1Y)
-		dev->bboard_cache[3].x = input.value;
 
 	goto try_again;
 }
@@ -1319,6 +1349,7 @@ static int read_pro(struct xwii_iface *dev, struct xwii_event *ev)
 	int ret, fd;
 	struct input_event input;
 	unsigned int key;
+	static bool EV_SYN_KEY = false;
 
 	fd = dev->ifs[XWII_IF_PRO_CONTROLLER].fd;
 	if (fd < 0)
@@ -1420,6 +1451,7 @@ try_again:
 				goto try_again;
 		}
 
+		EV_SYN_KEY = true;
 		memset(ev, 0, sizeof(*ev));
 		memcpy(&ev->time, &input.time, sizeof(struct timeval));
 		ev->type = XWII_EVENT_PRO_CONTROLLER_KEY;
@@ -1436,6 +1468,11 @@ try_again:
 		else if (input.code == ABS_RY)
 			dev->pro_cache[1].y = input.value;
 	} else if (input.type == EV_SYN) {
+		if (EV_SYN_KEY) {
+			EV_SYN_KEY = false;
+			goto try_again;
+		}
+
 		memset(ev, 0, sizeof(*ev));
 		memcpy(&ev->time, &input.time, sizeof(struct timeval));
 		memcpy(&ev->v.abs, dev->pro_cache,
@@ -1453,6 +1490,7 @@ static int read_drums(struct xwii_iface *dev, struct xwii_event *ev)
 	int ret, fd;
 	struct input_event input;
 	unsigned int key;
+	static bool EV_SYN_KEY = false;
 
 	fd = dev->ifs[XWII_IF_DRUMS].fd;
 	if (fd < 0)
@@ -1485,6 +1523,7 @@ try_again:
 			goto try_again;
 		}
 
+		EV_SYN_KEY = true;
 		memset(ev, 0, sizeof(*ev));
 		memcpy(&ev->time, &input.time, sizeof(struct timeval));
 		ev->type = XWII_EVENT_DRUMS_KEY;
@@ -1532,6 +1571,11 @@ try_again:
 		else if (input.code == ABS_HI_HAT)
 			dev->drums_cache[XWII_DRUMS_ABS_HI_HAT].x = input.value;
 	} else if (input.type == EV_SYN) {
+		if (EV_SYN_KEY) {
+			EV_SYN_KEY = false;
+			goto try_again;
+		}
+
 		memset(ev, 0, sizeof(*ev));
 		memcpy(&ev->time, &input.time, sizeof(struct timeval));
 		memcpy(&ev->v.abs, dev->drums_cache,
@@ -1548,6 +1592,7 @@ static int read_guitar(struct xwii_iface *dev, struct xwii_event *ev)
 	int ret, fd;
 	struct input_event input;
 	unsigned int key;
+	static bool EV_SYN_KEY = false;
 
 	fd = dev->ifs[XWII_IF_GUITAR].fd;
 	if (fd < 0)
@@ -1622,6 +1667,7 @@ try_again:
 			goto try_again;
 		}
 
+		EV_SYN_KEY = true;
 		memset(ev, 0, sizeof(*ev));
 		memcpy(&ev->time, &input.time, sizeof(struct timeval));
 		ev->type = XWII_EVENT_GUITAR_KEY;
@@ -1644,6 +1690,11 @@ try_again:
 		else if (input.code == ABS_FRET_BOARD)
 			dev->guitar_cache[2].x = input.value;
 	} else if (input.type == EV_SYN) {
+		if (EV_SYN_KEY) {
+			EV_SYN_KEY = false;
+			goto try_again;
+		}
+
 		memset(ev, 0, sizeof(*ev));
 		memcpy(&ev->time, &input.time, sizeof(struct timeval));
 		memcpy(&ev->v.abs, dev->guitar_cache,

--- a/lib/xwiimote.h
+++ b/lib/xwiimote.h
@@ -422,6 +422,16 @@ enum xwii_event_types {
 	XWII_EVENT_BALANCE_BOARD,
 
 	/**
+	 * Balance-Board key event
+	 *
+	 * Button event of the Balance-Board is reported via this interface
+	 * and not via the core-interface (which only reports core-buttons).
+	 * Valid button: A
+	 * Payload type is struct xwii_event_key.
+	 */
+	XWII_EVENT_BALANCE_BOARD_KEY,
+
+	/**
 	 * Motion-Plus event
 	 *
 	 * Motion-Plus gyroscope events. These describe rotational speed, not

--- a/tools/xwiishow.c
+++ b/tools/xwiishow.c
@@ -2569,6 +2569,9 @@ static int run_iface(struct xwii_iface *iface)
 				if (mode == MODE_EXTENDED)
 					bboard_show_ext(&event);
 				break;
+			case XWII_EVENT_BALANCE_BOARD_KEY:
+				key_show(&event);
+				break;
 			case XWII_EVENT_PRO_CONTROLLER_KEY:
 			case XWII_EVENT_PRO_CONTROLLER_MOVE:
 				if (mode == MODE_EXTENDED)


### PR DESCRIPTION
Ignore EV_SYN events after keys events.  Stop garbage event from being returned.

Patch squashed with cleaned up indentation and addressing all comments listed in pull request #77 by Petter Reinholdtsen.