### PR TITLE
Report LED number when read failed.

### DIFF
--- a/tools/xwiishow.c
+++ b/tools/xwiishow.c
@@ -2169,7 +2169,7 @@ static void led_refresh(int n)
 
 	ret = xwii_iface_get_led(iface, XWII_LED(n+1), &led_state[n]);
 	if (ret)
-		print_error("Error: Cannot read LED state");
+		print_error("Error: Cannot read LED #%i state", n+1);
 	else
 		led_show(n, led_state[n]);
 }


### PR DESCRIPTION
Provide more information for debugging.

This change was lifted from #77, originally created by sahoahfoa.